### PR TITLE
Enable OPTIMADE structure importer

### DIFF
--- a/submit_calculations.ipynb
+++ b/submit_calculations.ipynb
@@ -73,6 +73,7 @@
     "    importers=[\n",
     "        awb.StructureUploadWidget(title=\"Import from computer\"),\n",
     "        awb.StructureBrowserWidget(title=\"AiiDA database\"),\n",
+    "        awb.OptimadeQueryWidget(embedded=True),\n",
     "        awb.SmilesWidget(title=\"From SMILES\"),\n",
     "        CdxmlUpload2GnrWidget(title=\"CDXML\"),\n",
     "    ],\n",


### PR DESCRIPTION
Enable the optimade structure importer, considering that molecules are supported in the optimade specification (https://github.com/Materials-Consortia/OPTIMADE/blob/v1.1.0/optimade.rst#id69).

Although to my knowledge, there is no optimade database of molecules yet.