### PR TITLE
added more exception types to the try/except to pre-evaluate CVs

### DIFF
--- a/surfaces_tools/widgets/constraints.py
+++ b/surfaces_tools/widgets/constraints.py
@@ -72,7 +72,7 @@ class OneConstraint(ipw.HBox):
             try:
                 cv_value = cp2k_utils.compute_colvars(change["new"], self.ase_atoms)
                 self.children[1].target_widget.value = str(round(cv_value[0][1], 3))
-            except IndexError:
+            except (IndexError, KeyError, ValueError) as e:
                 pass
 
 


### PR DESCRIPTION
In the GUI when typing CV details a try/except allows to avoid crashes for on the fly evaluation of the CV. KeyError and ValueError added as exception cases