### PR TITLE
SPM orbital calc: don't require carbon to be present

### DIFF
--- a/surfaces_tools/utils/spm.py
+++ b/surfaces_tools/utils/spm.py
@@ -125,7 +125,7 @@ def create_orbitals_parameterdata(
         "--wfn_file": parent_dir + "aiida-RESTART.wfn",
         "--hartree_file": parent_dir + "aiida-HART-v_hartree-1_0.cube",
         "--orb_output_file": "orb.npz",
-        "--eval_region": ["G", "G", "G", "G", "n-1.0_C", "p%.1f" % extrap_plane],
+        "--eval_region": ["G", "G", "G", "G", "n-1.0", "p%.1f" % extrap_plane],
         "--dx": "0.15",
         "--eval_cutoff": "16.0",
         "--extrap_extent": str(extrap_extent),


### PR DESCRIPTION
Hi, the spm orbital calculation currently requires carbon to be present in the system (as the evaluation region is defined w.r.t. it).

This change allows any molecule to be calculated.

I currently didn't have time to test (as i need to set up computers/codes) but i'm quite sure this simple change should work correctly.

@dpasserone @yakutovicha 