### PR TITLE
fix search bug and update dependency on awe to 0.2.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     aiida-core~=2.2
     aiida-nanotech-empa>=v1.0.0b10
     aiidalab-widgets-base[smiles]>=2.3.1,<3.0
-    aiidalab-widgets-empa>=0.2.1
+    aiidalab-widgets-empa>=0.2.2
     ase>=3.24
 python_requires = >=3.9
 

--- a/surfaces_tools/widgets/search_structures_widget.py
+++ b/surfaces_tools/widgets/search_structures_widget.py
@@ -230,6 +230,12 @@ class SearchStructuresWidget(ipw.VBox):
                             energy=energy,
                             pk_eq_geo=pk_eq_geo,
                         )
+                    else:
+                        html += link_to_viewer(
+                            description=f"PK-{node.pk} {node.description}",
+                            pk=node.pk,
+                            label=node.label,
+                        )
 
                 html += "</ul></td>"
                 if nrows_done == 0:


### PR DESCRIPTION
Due to an error in the search logic, only calculations of geo_opt type were showing details in the search results table